### PR TITLE
移除 [idea`s blog]

### DIFF
--- a/blogs-original.csv
+++ b/blogs-original.csv
@@ -44,7 +44,6 @@ Cat in Chinese, https://chinese.catchen.me, http://chinese.catchen.me/feeds/post
 Randy's Blog, https://lutaonan.com, https://lutaonan.com/rss.xml, 编程
 iTimothy, https://xiaozhou.net, https://xiaozhou.net/atom.xml, 编程
 F.B, http://www.fanbing.net, http://www.fanbing.net/feed, 编程
-idea's blog, http://www.ideawu.net/blog, http://www.ideawu.net/blog/feed, 编程
 透明思考, http://gigix.thoughtworkers.org, http://gigix.thoughtworkers.org/atom.xml, 编程
 xiaix's Blog, https://xiaix.me, http://xiaix.me/rss/, 编程
 搞笑談軟工, http://teddy-chen-tw.blogspot.com, http://teddy-chen-tw.blogspot.com/feeds/posts/default, 编程


### PR DESCRIPTION
移除字段：idea's blog, http://www.ideawu.net/blog, http://www.ideawu.net/blog/feed, 编程

理由：
2020/10/03 我发现其域名被重定向到博主的github主页，由于没找到博主其他联系方式，于是通过在其 github 项目中里发[issue](https://github.com/ideawu/ssdb-docs/issues/36)联系博主以询问其原因。
同日晚，博主close了 issue，但并没有给出任何回复。

至今2021/02/07，未观察到此博客恢复。

详情：https://t.me/blogrsslist/90