### PR TITLE
修改木子的博客域名

### DIFF
--- a/blogs-original.csv
+++ b/blogs-original.csv
@@ -273,7 +273,7 @@ not LSD, https://notlsd.github.io, https://notlsd.github.io/atom.xml, 编程; �
 杯酒故事, https://beijiu.ink, , 文学; 小说; 诗歌
 失眠海峡, https://blog.imalan.cn, https://blog.imalan.cn/feed.xml, 编程; 日常; 二次元; 读书
 DuyaoSS, https://www.duyaoss.com/, https://www.duyaoss.com/feed/, SS; SSR
-木子, https://blog.502.li/, https://blog.502.li/atom.xml, Linux; 科学上网; 读书笔记; 运维; 隐私; android
+木子, https://blog.k8s.li/, https://blog.k8s.li/atom.xml, Linux; 科学上网; 读书笔记; 运维; 隐私; android
 wuxinhua's Blog, https://wuxinhua.com/, https://wuxinhua.com/atom.xml, 生活; 编程; 随想
 Dasyatis, https://www.bobby285271.top/, , 编程; Linux
 薛定喵君的博客, http://blog.xuedingmiao.com/, , 编程; 前端; 产品; 笔记


### PR DESCRIPTION
[木子](https://blog.502.li/)已更换域名，但并未向此项目提交索引更新，故帮其更新索引。