### PR TITLE
Update [仙神の小屋]to[Lu Shuyu]

### DIFF
--- a/blogs-original.csv
+++ b/blogs-original.csv
@@ -239,7 +239,7 @@ CRIMX Blog, https://blog.crimx.com/, https://blog.crimx.com/rss.xml, 编程; 前
 Michael翔, https://michael728.github.io/, https://michael728.github.io/atom.xml, 编程; DevOps; 随笔
 Dosk 技术站, https://www.dosk.win/, https://www.dosk.win/feed.xml, 编程; 前端; C++
 会打篮球的程序猿, http://www.lzhpo.com, , 编程; 福利; 技术; 生活
-仙神の小屋, https://blog.aqours.life/, https://blog.aqours.life/feed/, 编程; OI; 随笔; 思考
+Lu Shuyu, https://blog.lushuyu.site/, https://blog.lushuyu.site/feed/, 编程; OI; 随笔; 思考
 Xieisabug, https://www.xiejingyang.com/, https://www.xiejingyang.com/feed/, 编程; 前端; 随笔; 思考; 创意
 郑泽鑫的博客, https://zhengzexin.com/, https://zhengzexin.com/feed/, 编程; 生物信息学; 生活
 雷全的个人网站, https://leiquan.website/, , 编程; 文学; 科技; 生活


### PR DESCRIPTION
访问 aqours.life，可找到其新的博客地址 blog.lushuyu.site

Blog Name:仙神の小屋 > Lu Shuyu
Site:blog.aqours.life > https://blog.lushuyu.site

Contributor:@lijiajunljj @gledos