### PR TITLE
Use RSS Registered with Feedly

### DIFF
--- a/blogs-original.csv
+++ b/blogs-original.csv
@@ -764,4 +764,4 @@ An's Blog, https://zincnode.com, https://zincnode.com/index.xml, 编程; 思考;
 xStack, http://www.xqmq.icu/, http://www.xqmq.icu/atom.xml, 笔记; 编程; 随笔
 烧饼博客, https://u.sb, https://u.sb/rss.xml, 运维; 域名
 xuetengfei'Blog, https://xuetengfei.github.io/, , 编程
-Lei Mao's Log Book, https://leimao.github.io/, https://leimao.github.io/atom.xml, 人工智能; 机器学习; 计算机科学; 编程
+Lei Mao's Log Book, https://leimao.github.io/, https://leimao.github.io/feed.xml, 人工智能; 机器学习; 计算机科学; 编程


### PR DESCRIPTION
Use the RSS registered with Feedly so that the number of subscribers could be correctly showed on the README.