### PR TITLE
substitute blog.keshankang.org with blogke.cn

### DIFF
--- a/blogs-original.csv
+++ b/blogs-original.csv
@@ -783,7 +783,7 @@ RUNNINGJ, https://runningj.top, https://runningj.top/feed.xml, 编程; 生活; �
 Frange Zone｜Xu's Blog, https://frangezone.github.io, https://frangezone.github.io/index.xml, 产品; 生活; 数码; 随笔
 程序员的喵, https://catcoding.me/, https://catcoding.me/atom.xml, 编程; 技术; 写作; 阅读; 分享
 后端工程师, https://hdgcs.com, https://hdgcs.com/feed.xml, 编程; 技术; 开源; 后端
-柯善康, https://blog.keshankang.org/, https://blog.keshankang.org/feed/, 记录; 分享
+BlogKe记录志, https://blogke.cn/index.html, https://blogke.cn/index.xml, 笔记; 想法
 nickChenyx, https://nickchenyx.github.io/, https://nickchenyx.github.io/atom.xml, 编程; 技术; 分享
 让我们一起发现西西里岛, https://mattia88.com/, https://mattia88.com/feed/, 西西里人; 西西里旅游
 Shadow Walker 松烟阁, https://www.edony.ink/, https://www.edony.ink/rss/, Linux 操作系统安全（LSM，ebpf 等）; 基础设施可信; 产品思考; 数字花园; Obsidian


### PR DESCRIPTION
blog.keshankang.org is no longer maintained...