### PR TITLE
modify: Add 'Cloudflare Pages' as a recommanded blog deployment platf…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1230,4 +1230,3 @@
 
   - [Netlify](https://www.netlify.com/)
   - [Vercel](https://vercel.com/)
-  - [Cloudflare Pages](https://pages.cloudflare.com/)

--- a/README.md
+++ b/README.md
@@ -1230,3 +1230,4 @@
 
   - [Netlify](https://www.netlify.com/)
   - [Vercel](https://vercel.com/)
+  - [Cloudflare Pages](https://pages.cloudflare.com/)

--- a/script.js
+++ b/script.js
@@ -150,6 +150,7 @@ ${tableContentInMD}
 
   - [Netlify](https://www.netlify.com/)
   - [Vercel](https://vercel.com/)
+  - [Cloudflare Pages](https://pages.cloudflare.com/)
 `
 
   fs.writeFileSync('./README.md', readmeContent, 'utf8');


### PR DESCRIPTION
## Summary

- Adding [Cloudflare Pages](https://pages.cloudflare.com/) as one of the recommanded deployment platforms.
- Cloudflare Pages might be the best free platform for static site generators.


Thx for reviewing. Best regards,