### PR TITLE
Update [Fred Wu's Blog] or remove it?

### DIFF
--- a/blogs-original.csv
+++ b/blogs-original.csv
@@ -112,7 +112,7 @@ Wiken, https://www.hehuapei.com, https://www.hehuapei.com/feed, 编程; 随笔; 
 kok的笔记本, https://wocai.de, https://wocai.de/index.xml/, 编程; 摄影
 搞搞震, https://www.wujingquan.com, https://www.wujingquan.com/atom.xml, 编程; 开源
 Qt进阶之路-涛哥的博客, https://jaredtao.github.io/, https://jaredtao.github.io/atom.xml, 编程; Qt
-Fred Wu's Blog, https://fredwu.me/, https://fredwu.me/rss.xml, 编程; 开源; 摄影; 设计; 领导; 澳洲
+Fred Wu's Blog, https://persumi.com/u/fredwu, https://persumi.com/u/fredwu/feed/rss, 编程; 开源; 摄影; 设计; 领导; 澳洲
 ISLAND, https://youngxhui.top, https://youngxhui.top/index.xml, 编程; 生活; 随笔
 贺叶霜的树, https://blog.heysh.xyz/, https://blog.heysh.xyz/feed.xml, 开源; 生活
 Frytea's Blog, https://blog.frytea.com, https://blog.frytea.com/feed, 编程; 思考; 高效


### PR DESCRIPTION
域名重定向到了博主自有的 persumi 内容平台。

---

## 问题1

其提供 atom 和 rss 格式的 feed ，但是其 [atom 格式的 feed](https://persumi.com/u/fredwu/feed/atom) 的 `feed:link` href 错误地指向了 `https://persumi.com/u/fredwu/feed/rss` 而不是 `https://persumi.com/u/fredwu` 主页。  

> `<link>` 默认属性是 `alternate`: "an alternate representation of the entry or feed, for example a permalink to the html version of the entry, or the front page of the weblog.") 
> ref: <https://validator.w3.org/feed/docs/atom.html#link>

cc: @fredwu

## 问题2

貌似文章都是全英，没发现中文博文，是否将其继续留在本中文独立博客列表有待商榷，这个收录问题稍后可能单独起个 issue 。