### PR TITLE
fix: RSS 订阅数一列太窄，导致字看不清；链接有些行太宽，导致表格需要左右滑动；

### DIFF
--- a/script.js
+++ b/script.js
@@ -58,16 +58,17 @@ async function getResultAndUpdateREADME() {
   const getFeedsPubBtn = (feedLink, followCount) => 
     `[<img src="https://img.shields.io/static/v1?label=follow&message=${followCount}&style=social&logo=rss">](https://feeds.pub/feed/${encodeURIComponent(feedLink)})`;
   const newTable = table.map(row => {
+    const url = new URL(row[1])
     return [
       row[2] ? getFeedsPubBtn(row[2], row[4]) : '',
       row[0].replace(/\|/g, '&#124;'),
-      row[1],
+      `[${url.protocol}//${url.host}/](${url.href})`,
       row[3]
     ]
   });
 
   // update README
-  const tableContentInMD = markdownTable([['RSS 订阅数 <img width=110/> ', '简介', '链接', '标签'], ...newTable]);
+  const tableContentInMD = markdownTable([['<p>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; RSS 订阅数</p>', '简介', '链接', '标签'], ...newTable]);
 
   const readmeContent = `
 # 中文独立博客列表


### PR DESCRIPTION
#1571 

`script.js`改好啦

因为是用脚本来生成，所以单独改某行不太方便，我就直接改的表头，这样表头的高度会变成两行。

我看 actions 里边有些接口调用，不知道在我的 repo 里跑 actions 会不会产生什么副作用，所以没测试`script.js`。

不过我本地手动改了下`README.md`看了下效果，是对的。