### PR TITLE
add `muspimerol.site`

### DIFF
--- a/blogs-original.csv
+++ b/blogs-original.csv
@@ -1285,3 +1285,4 @@ WSH, https://wsh233.cn, https://www.wsh233.cn/feed.xml, 生活; 随笔; GISer; �
 Heggria, https://heggria.site/, https://heggria.site/feed.xml, 技术; 生活; 编程; 前端
 Sehnsucht, https://blog.sehnsucht.top/, https://blog.sehnsucht.top/rss.xml, 技术; 生活; 随笔; 读书; 杂谈; 娱乐; 思考
 RisingIce, https://www.imrising.cn/, https://www.imrising.cn/sitemap.xml, 技术; 生活; 随笔; AIGC
+Muspi Merol 的个人主页, https://muspimerol.site, https://muspimerol.site/feed, 随笔


### PR DESCRIPTION
#### Summary generated by Github Copilot

This pull request includes a small change to the `blogs-original.csv` file. The change adds a new blog entry to the list.

* [`blogs-original.csv`](diffhunk://#diff-7ce875aab53261253f1ee3e45f4aeacd3c4795c1cc00021f1f97dd095cb22fb6R1288): Added "Muspi Merol 的个人主页" with its URL and feed link.