### PR TITLE
刘郎阁

### DIFF
--- a/blogs-original.csv
+++ b/blogs-original.csv
@@ -1428,3 +1428,4 @@ QingCCL, https://qingccl.github.io/, https://qingccl.github.io/rss.xml, 文学; 
 翔宇工作流, https://xiangyugongzuoliu.com/, https://xiangyugongzuoliu.com/latest/rss/, AI; 编程; 自动化; Claude Code; 教程
 初然忆, https://www.imcry.vip/, https://www.imcry.vip/index.xml, 编程; 生活; 记录
 MakerJackie, https://makerjackie.com/, , AI; 产品; 全栈; 编程; 随笔
+刘郎阁,https://vjo.cc/,https://vjo.cc/feed/,编程; 生活; 记录; 随笔


### PR DESCRIPTION
将刘郎阁的博客 https://vjo.cc/ 添加到blogs-original.csv文件