### PR TITLE
Add Amiya's desk blog

### DIFF
--- a/blogs-original.csv
+++ b/blogs-original.csv
@@ -1433,3 +1433,4 @@ Im Patrick,https://impatrick.blog/,https://impatrick.blog/feed/,繁中; 攝影; 
 cocolia小窝,https://cocolia.fun/,https://cocolia.fun/feed.xml,编程; 生活; 摄影; AI
 Dax,https://daolanx.me/zh/,https://daolanx.me/zh/rss.xml,编程; 全栈; 生活
 Haku,https://re.karlbaey.top,https://re.karlbaey.top/rss.xml,技术; 生活; 编程; 文学; 随笔
+Amiya的书桌,https://blog.sayori.org/,https://blog.sayori.org/rss.xml,日记; 资源; 技术


### PR DESCRIPTION
Adds Amiya的书桌 to the Chinese independent blogs list.

Blog: https://blog.sayori.org/
RSS: https://blog.sayori.org/rss.xml
Tags: 日记; 资源; 技术

Validation:
- python linter.py