### PR TITLE
Add Oleg Tech Blog to the list

### DIFF
--- a/blogs-original.csv
+++ b/blogs-original.csv
@@ -1436,3 +1436,4 @@ Haku,https://re.karlbaey.top,https://re.karlbaey.top/rss.xml,技术; 生活; 编
 Amiya的书桌,https://blog.sayori.org/,https://blog.sayori.org/rss.xml,日记; 资源; 技术
 郭飞的笔记,https://www.guofei.site/,,算法; 编程; 开源; 读书
 星觅海的博客,https://www.xmhai.cn/,https://www.xmhai.cn/rss.xml,技术; 生活; 资源
+Oleg's Tech Blog,https://timoshinoleg-eng.github.io/blog/,https://timoshinoleg-eng.github.io/blog/feed.xml,Python; Telegram; AI; Bot


### PR DESCRIPTION
Adds [Oleg Tech Blog](https://timoshinoleg-eng.github.io/blog/) to the Chinese independent blogs list.

Blog: https://timoshinoleg-eng.github.io/blog/
RSS: https://timoshinoleg-eng.github.io/blog/feed.xml
Tags: Python; Telegram; AI; Bot

Validation:
- python linter.py passed