### PR TITLE
Add BotForge Notes

### DIFF
--- a/blogs-original.csv
+++ b/blogs-original.csv
@@ -1441,3 +1441,4 @@ MoeBlog,https://1loli.link/,https://1loli.link/feed/,技术; AI; 编程; 随笔
 AI学习日记,https://livk30.github.io/,https://livk30.github.io/rss.xml,AI; 机器学习; 深度学习
 冰冻大西瓜的博客,https://bddxg.top/, https://bddxg.top/feed.rss, 前端; 编程; 生活; AI
 毛英龙的数字花园, https://blog.rnm.gv.uy/, https://blog.rnm.gv.uy/atom.xml, 编程; 开源; 前端; 折腾; 数字生活; agent; openclaw; Hermes
+BotForge Notes, https://blog.notlove.me/, https://blog.notlove.me/feed.xml, AI; Telegram; Bot; 编程; 自动化


### PR DESCRIPTION
Add BotForge Notes, an independent Chinese tech blog about Telegram bots, AI automation, lead collection workflows, and small-business VPS deployment.

The site has original posts and a valid RSS feed:
 https://blog.notlove.me/
https://blog.notlove.me/feed.xml
