### PR TITLE
Add 杨轩的博客 (yangxuan.ai)

### DIFF
--- a/blogs-original.csv
+++ b/blogs-original.csv
@@ -1453,3 +1453,4 @@ Abyss的小屋, https://www.rsnocsi.cn/, https://www.rsnocsi.cn/feed, AI; 技术
 wmhwiki, https://wmhwiki.cn/, https://wmhwiki.cn/rss.xml, 技术; 生活
 Victor42, https://victor42.eth.limo, https://victor42.eth.limo/index.xml,科学; 数据分析; 设计; 游记; 开发者
 创见思考, https://www.fengcan.net, https://www.fengcan.net/feed/, AI; 读书; 医疗; 人生决策
+杨轩的博客:AI×投资实盘记录, https://yangxuan.ai, https://yangxuan.ai/feed/, AI; 投资; 量化


### PR DESCRIPTION
按提交规范在 blogs-original.csv 尾部新增一行:

- 博客:杨轩的博客:AI×投资实盘记录
- 地址:https://yangxuan.ai
- RSS:https://yangxuan.ai/feed/
- 标签:AI; 投资; 量化

已在本地跑过 linter.py,通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)