### PR TITLE
Add Arthur's Review

### DIFF
--- a/blogs-original.csv
+++ b/blogs-original.csv
@@ -1459,3 +1459,4 @@ MOMB闲谈, https://www.momb.top, https://www.momb.top/rss/feed.xml, 热点; 随
 胡东东博客,https://blog.hudd.cn/, https://blog.hudd.cn/feed/, 前端; 编程; 技术; AI
 猿客随笔,https://monkeyke.com/, https://monkeyke.com/index.xml, 编程; 生活; 随笔
 戈壁有耳, https://www.zhanggeer.net/, https://www.zhanggeer.net/feed/, 生活; 随笔; 摄影; 音乐
+Arthur's Review, https://blog.leesaitool.com, https://blog.leesaitool.com/feed.xml, AI; 社会; 哲学; 随笔


### PR DESCRIPTION
Adds Arthur's Review, an original independent blog covering AI, society, philosophy, and essays.\n\n- Blog: https://blog.leesaitool.com\n- RSS: https://blog.leesaitool.com/feed.xml\n\nThe RSS endpoint was verified to return HTTP 200 with application/rss+xml.