### PR TITLE
Add 楼船INKFLAKE to blog list

### DIFF
--- a/blogs-original.csv
+++ b/blogs-original.csv
@@ -1471,3 +1471,4 @@ Dort 的博客, https://blog.dort.me/, https://blog.dort.me/rss.xml, 随笔; 生
 67的博客, https://www.liuqi.cc/, https://www.liuqi.cc/rss/feed.xml, 编程; 生活; 记录; 随笔
 DataShare 数据人阿多, https://datashare-duo.github.io/datashare-blog/, https://datashare-duo.github.io/datashare-blog/rss.xml, 编程; 数据; 随笔; 技术; AI; 机器学习
 热衷于的博客, https://zooyoo.top/, https://zooyoo.top/feed/, 生活; 技术; 随笔; 观察
+楼船INKFLAKE, https://fravilion.top, https://fravilion.top/index.php/feed/, 随笔; 生活; 旅行; 摄影; 数码


### PR DESCRIPTION
添加博客：楼船INKFLAKE (fravilion.top)

- 名称：楼船INKFLAKE
- 地址：https://fravilion.top
- RSS：https://fravilion.top/index.php/feed/
- 标签：随笔; 生活; 旅行; 摄影; 数码

Typecho 搭建的个人博客，主要记录大学生活、博物馆旅行游记、数码体验和随笔。