### PR TITLE
Update Alliot's blog domain

### DIFF
--- a/blogs-original.csv
+++ b/blogs-original.csv
@@ -682,7 +682,7 @@ jdhao's blog, https://jdhao.github.io/, https://jdhao.github.io/index.xml, 编�
 王小嗨的不老歌, https://sogola.com/, https://sogola.com/index.xml, 马克思主义; 工人; 工厂; 读书; 翻译
 东泽煮粥, https://eurychen.me/, https://eurychen.me/index.xml, 机器学习; 区块链; 音乐; 生活
 icy's blog, https://icys.top/, https://icys.top/atom.xml, 编程; 思考; 笔记
-Alliot's blog, https://www.iots.vip/, https://www.iots.vip/atom.xml, 编程; 技术; 运维; 硬件
+Alliot's blog, https://blog.alliot.tech/, https://blog.alliot.tech/atom.xml, 编程; 技术; 运维; 硬件
 程序员充电站, https://itcharge.cn, https://itcharge.cn/feed/, iOS; 算法; 数据结构; 生活
 Yuk的部落格, https://blog.yuk7.com/, https://blog.yuk7.com/atom.xml, 编程; 技术; 绘画; 生活
 Domon, https://www.domon.cn/, https://www.domon.cn/rss/, 技术; 生活; 产品


### PR DESCRIPTION
将 Alliot's blog 的主页和 RSS 地址从 `www.iots.vip` 更新为新域名 `blog.alliot.tech`。

验证：
- `https://blog.alliot.tech/` 返回 HTTP 200
- `https://blog.alliot.tech/atom.xml` 返回有效 Atom Feed
- `python3 linter.py` 通过