### PR TITLE
Add Zopiya blog

### DIFF
--- a/blogs-original.csv
+++ b/blogs-original.csv
@@ -1474,3 +1474,4 @@ DataShare 数据人阿多, https://datashare-duo.github.io/datashare-blog/, http
 楼船INKFLAKE, https://fravilion.top, https://fravilion.top/index.php/feed/, 随笔; 生活; 旅行; 摄影; 数码
 三叶的博客, https://blog.cloverta.top/, https://blog.cloverta.top/rss.xml, 随笔; 生活; 技术; 编程
 李不言的博客, https://libuyan.top, https://libuyan.top/rss.xml, 技术; 思考; 量化; 随笔
+仲平 · 文辑, https://blog.zopiya.com, https://blog.zopiya.com/rss.xml, 生活; 开发; 旅行; 摄影; 分享


### PR DESCRIPTION
Add the long-form blog at blog.zopiya.com and its RSS feed.

The previous blog.7wate.com entry is intentionally retained as a separate legacy-domain record.