### PR TITLE
新增 Samadhi 個人博客與中文 RSS

### DIFF
--- a/blogs-original.csv
+++ b/blogs-original.csv
@@ -1482,3 +1482,4 @@ WangZR's Blog, https://zirui.wang, , 技术，摄影，随笔，无线电
 Sanmussh Blog, https://blog.movcloud.xyz, https://blog.movcloud.xyz/rss.xml, 技术; AI; 知识; 随笔
 Sagasu, https://www.sagasu.art, https://www.sagasu.art/rss.xml, AI; 编程; 产品; 独立开发
 冉江龙的个人空间, https://www.ranjl.cn/, , 技术; 编程; AI; 产品; 随笔
+Samadhi — 關於我，未完的筆記, https://samadhi.blog/, https://samadhi.blog/feed.xml, 生活; 随笔; 自我探索


### PR DESCRIPTION
新增 Samadhi 的中文首頁與中文 RSS，分類為生活、隨筆、自我探索。

Samadhi 是個人生活與自我探索的獨立博客，目前有兩篇原創文章，主題是成就與自我認同，以及人生是否需要一個最終目的。網站剛於 2026 年 9 月開始發布，並有對應英文版本。此為網站方自薦收錄。

- 中文首頁：https://samadhi.blog/
- 中文 RSS：https://samadhi.blog/feed.xml
- 英文首頁：https://samadhi.blog/en/
- 英文 RSS：https://samadhi.blog/en/feed.xml

依 README 的投稿方式，只在 `blogs-original.csv` 末尾新增一行。已執行 `python3 linter.py` 通過，並確認中文 RSS 回傳 HTTP 200、可解析且含兩篇文章。
